### PR TITLE
Add scroll-first manhwa reader prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# PanelFlow
+
+PanelFlow is a lightweight prototype for a scroll-first manhwa reader. It focuses on a frictionless reading experience, quick chapter uploads, and a design system that can scale into a production-ready platform.
+
+## Features
+- **Immersive reader**: Vertical scrolling layout with lazy-loaded pages, chapter navigation, and automatic progress tracking in `localStorage`.
+- **Library management**: Browse series from the homepage or the full library view. Chapters are organized chronologically per series.
+- **Admin uploads**: Drag & drop uploader that sorts page images, persists them locally as data URLs, and refreshes the library snapshot instantly.
+- **Theme system**: Dark mode by default with an accessible light-mode toggle and `prefers-color-scheme` detection.
+- **Responsive UI**: Touch-friendly hit targets, fluid layouts, and sticky headers for desktop and mobile readers.
+
+## Local storage strategy
+- `panelflow-library-v1` stores all series, chapters, and page metadata including base64 image data. This keeps the prototype self-contained.
+- `panelflow-progress-v1` persists scroll offset per chapter to resume reading.
+- Storage helpers live in `assets/js/storage.js` so they can later be swapped with API calls without changing UI layers.
+
+## UX considerations
+- Keep navigation persistent via sticky headers while maximizing reading canvas.
+- Use large touch-friendly buttons and vertical spacing to avoid accidental taps on mobile.
+- Lazy-load images with `loading="lazy"` and pre-sorted pages to prevent layout shifts.
+- Provide progress feedback and quick chapter switching via the sticky dropdown.
+- Offer immediate empty-state guidance on first load.
+
+## Migrating to a production stack
+1. **Backend service**: Introduce a Node.js or NestJS API with authentication and role-based access (admin vs. reader).
+2. **Persistent storage**: Replace local storage with MongoDB or PostgreSQL. Store image assets in object storage (AWS S3, Cloudflare R2) and keep metadata references in the database.
+3. **Uploads**: Convert the admin uploader to send `FormData` to the API. Use presigned URLs for direct-to-storage uploads.
+4. **Image optimization**: Integrate an image CDN or server-side transformer to deliver WebP/AVIF, dynamic resizing, and smart cropping.
+5. **Caching & performance**: Leverage HTTP caching headers, incremental static regeneration (Next.js), or service workers for offline reading.
+6. **Security**: Add JWT-based auth, rate limiting on uploads, and validation to guard against malformed files.
+
+## Development notes
+- The project uses plain HTML/CSS/JS to stay framework-agnostic.
+- All scripts are ES modules so they can be bundled later.
+- To reset demo data, use the **Reset Library** button in the admin panel.
+- Because data URLs can be large, this prototype is meant for short demo chapters. Move to a real backend before uploading production-sized chapters.

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Upload Dashboard - PanelFlow</title>
+  <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body class="page-admin">
+  <header class="site-header">
+    <div class="logo">PanelFlow</div>
+    <nav class="main-nav">
+      <a href="index.html">Home</a>
+      <a href="series.html">Series</a>
+      <a href="admin.html" class="active">Upload</a>
+    </nav>
+    <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme"></button>
+  </header>
+
+  <main class="page-content">
+    <header class="section-header">
+      <h1>Upload Manager</h1>
+      <p>Drag & drop chapter images or use the upload buttons. Pages are sorted automatically.</p>
+    </header>
+
+    <section class="upload-panel">
+      <form id="uploadForm" class="upload-form">
+        <div class="field-group">
+          <label for="seriesTitle">Series Title</label>
+          <input id="seriesTitle" name="seriesTitle" type="text" required placeholder="Enter series name" />
+        </div>
+        <div class="field-group">
+          <label for="seriesDescription">Series Description</label>
+          <textarea id="seriesDescription" name="seriesDescription" rows="3" placeholder="Optional blurb"></textarea>
+        </div>
+        <div class="field-group">
+          <label for="coverImage">Cover Image</label>
+          <input id="coverImage" name="coverImage" type="file" accept="image/png, image/jpeg" />
+        </div>
+        <div class="field-group">
+          <label for="chapterTitle">Chapter Title</label>
+          <input id="chapterTitle" name="chapterTitle" type="text" required placeholder="Chapter name or number" />
+        </div>
+        <div class="field-group">
+          <label>Chapter Images</label>
+          <div id="dropZone" class="drop-zone" tabindex="0">Drop images here or click to browse</div>
+          <input id="chapterImages" name="chapterImages" type="file" accept="image/png, image/jpeg" multiple hidden />
+          <ul id="fileList" class="file-list"></ul>
+        </div>
+        <div class="actions">
+          <button type="submit" class="btn primary">Save Chapter</button>
+          <button type="button" id="clearLibrary" class="btn danger">Reset Library</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="library-overview">
+      <h2>Library Overview</h2>
+      <div id="libraryList" class="library-list"></div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>&copy; <span id="year"></span> PanelFlow.</p>
+  </footer>
+
+  <script type="module" src="assets/js/theme.js"></script>
+  <script type="module" src="assets/js/storage.js"></script>
+  <script type="module" src="assets/js/admin.js"></script>
+</body>
+</html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,464 @@
+:root {
+  color-scheme: dark light;
+  --bg: #0f1115;
+  --bg-elevated: #151921;
+  --bg-soft: #1c212b;
+  --text: #f5f6fb;
+  --text-muted: #a5adc6;
+  --accent: #66b3ff;
+  --accent-strong: #8ad6ff;
+  --danger: #ff6b6b;
+  --border: rgba(255, 255, 255, 0.06);
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 10px;
+  --transition: 0.2s ease;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+[data-theme="light"] {
+  --bg: #f7f8fc;
+  --bg-elevated: #ffffff;
+  --bg-soft: #eef1f8;
+  --text: #0f172a;
+  --text-muted: #475569;
+  --accent: #2563eb;
+  --accent-strong: #3b82f6;
+  --border: rgba(15, 23, 42, 0.1);
+  --shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+.hidden {
+  display: none !important;
+}
+
+html,
+body {
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.site-header,
+.reader-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem clamp(1rem, 4vw, 3rem);
+  background: rgba(10, 12, 16, 0.6);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.reader-header {
+  background: rgba(10, 12, 16, 0.85);
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.25rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.main-nav {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.main-nav a {
+  padding: 0.5rem 0.9rem;
+  border-radius: var(--radius-sm);
+  transition: background var(--transition), color var(--transition);
+  color: var(--text-muted);
+}
+
+.main-nav a.active,
+.main-nav a:hover {
+  color: var(--text);
+  background: rgba(102, 179, 255, 0.12);
+}
+
+.theme-toggle {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  cursor: pointer;
+  position: relative;
+}
+
+.theme-toggle::before {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  opacity: 0.7;
+  transition: transform var(--transition), opacity var(--transition);
+}
+
+[data-theme="light"] .theme-toggle::before {
+  transform: scale(0.7);
+  opacity: 0.85;
+}
+
+.btn {
+  border: none;
+  cursor: pointer;
+  border-radius: 999px;
+  padding: 0.75rem 1.6rem;
+  font-weight: 600;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #0b1020;
+}
+
+.btn.secondary {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+}
+
+.btn.danger {
+  background: var(--danger);
+  color: #fff;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow);
+}
+
+.page-content,
+.home-content,
+.reader-main {
+  width: min(1100px, 90vw);
+  margin: 0 auto;
+  padding: clamp(1rem, 3vw, 2.5rem) 0 4rem;
+  flex: 1;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(1.5rem, 4vw, 3.5rem);
+  align-items: center;
+  margin: 2rem 0 3rem;
+}
+
+.hero-copy h1 {
+  font-size: clamp(2.5rem, 5vw, 3.75rem);
+  line-height: 1.1;
+}
+
+.hero-copy p {
+  color: var(--text-muted);
+  margin: 1rem 0 1.5rem;
+  max-width: 36ch;
+}
+
+.hero-visual {
+  width: 100%;
+  min-height: 280px;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(140deg, rgba(102, 179, 255, 0.35), rgba(138, 214, 255, 0.1)),
+    url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 400 400"><defs><linearGradient id="a" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="%2366b3ff"/><stop offset="1" stop-color="%238ad6ff" stop-opacity="0"/></linearGradient></defs><rect width="400" height="400" fill="%230f1115"/><circle cx="320" cy="80" r="70" fill="url(%23a)"/><circle cx="120" cy="320" r="110" fill="url(%23a)"/></svg>') center/cover;
+  box-shadow: var(--shadow);
+}
+
+.section-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.filter-group input {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.7rem 1rem;
+  color: var(--text);
+  min-width: 220px;
+}
+
+.series-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.series-card {
+  background: var(--bg-elevated);
+  border-radius: var(--radius-md);
+  padding: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  transition: transform var(--transition), border-color var(--transition);
+}
+
+.series-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(102, 179, 255, 0.4);
+}
+
+.series-cover {
+  width: 100%;
+  aspect-ratio: 3/4;
+  border-radius: var(--radius-sm);
+  object-fit: cover;
+  background: var(--bg-soft);
+}
+
+.series-meta h3 {
+  font-size: 1.1rem;
+}
+
+.series-meta p {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.series-actions {
+  margin-top: auto;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.empty-state {
+  text-align: center;
+  color: var(--text-muted);
+  margin-top: 2rem;
+}
+
+.site-footer,
+.reader-footer {
+  text-align: center;
+  padding: 1.5rem;
+  color: var(--text-muted);
+  border-top: 1px solid var(--border);
+}
+
+.reader-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.reader-meta h1 {
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+}
+
+.reader-meta h2 {
+  color: var(--text-muted);
+  font-size: clamp(1.1rem, 3vw, 1.4rem);
+}
+
+.page-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  scroll-margin-top: 100px;
+}
+
+.reader-page {
+  width: min(820px, 100%);
+  margin: 0 auto;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--bg-soft);
+  box-shadow: var(--shadow);
+}
+
+.reader-page img {
+  width: 100%;
+  display: block;
+  height: auto;
+}
+
+.reader-pagination {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.page-admin .upload-panel,
+.page-admin .library-overview {
+  background: var(--bg-elevated);
+  border-radius: var(--radius-md);
+  padding: 1.8rem;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.upload-form {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.field-group {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.field-group input,
+.field-group textarea {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1rem;
+  color: var(--text);
+}
+
+.drop-zone {
+  border: 2px dashed rgba(102, 179, 255, 0.4);
+  border-radius: var(--radius-sm);
+  padding: 2.5rem 1rem;
+  text-align: center;
+  background: rgba(102, 179, 255, 0.05);
+  cursor: pointer;
+  transition: border-color var(--transition), background var(--transition);
+}
+
+.drop-zone.dragover {
+  border-color: var(--accent-strong);
+  background: rgba(102, 179, 255, 0.12);
+}
+
+.file-list {
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.library-list {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.library-item {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 1rem;
+  background: var(--bg-soft);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.library-item h3 {
+  font-size: 1rem;
+}
+
+.library-item ul {
+  list-style: none;
+  display: grid;
+  gap: 0.35rem;
+  color: var(--text-muted);
+}
+
+.reader-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.reader-controls select {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.65rem 1rem;
+  color: var(--text);
+  min-width: 200px;
+}
+
+.reader-header .btn {
+  padding: 0.55rem 1.2rem;
+}
+
+@media (max-width: 768px) {
+  .site-header,
+  .reader-header {
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+  }
+
+  .reader-controls {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .reader-controls select {
+    flex: 1;
+  }
+
+  .series-grid {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  }
+
+  .reader-pagination {
+    flex-direction: column;
+  }
+
+  .btn {
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-copy h1 {
+    font-size: 2.1rem;
+  }
+
+  .reader-header {
+    position: static;
+  }
+
+  .reader-main {
+    padding-top: 1rem;
+  }
+
+  .page-container {
+    gap: 0.8rem;
+  }
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,137 @@
+import { libraryStore, listSeries, upsertSeries, addChapter, fileToDataUrl } from './storage.js';
+
+const form = document.getElementById('uploadForm');
+const dropZone = document.getElementById('dropZone');
+const hiddenFileInput = document.getElementById('chapterImages');
+const fileList = document.getElementById('fileList');
+const libraryList = document.getElementById('libraryList');
+const clearLibrary = document.getElementById('clearLibrary');
+
+let queuedFiles = [];
+
+const refreshLibrary = () => {
+  libraryList.innerHTML = '';
+  const series = listSeries();
+  if (!series.length) {
+    libraryList.innerHTML = '<p class="empty-state">No chapters yet.</p>';
+    return;
+  }
+
+  series.forEach(entry => {
+    const item = document.createElement('article');
+    item.className = 'library-item';
+    item.innerHTML = `
+      <h3>${entry.title}</h3>
+      <p>${entry.description || 'No description.'}</p>
+    `;
+
+    const chapterList = document.createElement('ul');
+    entry.chapters.forEach(chapter => {
+      const li = document.createElement('li');
+      li.textContent = `${chapter.title} • ${chapter.pages.length} pages`;
+      chapterList.appendChild(li);
+    });
+
+    item.appendChild(chapterList);
+    libraryList.appendChild(item);
+  });
+};
+
+const updateFileList = () => {
+  fileList.innerHTML = '';
+  if (!queuedFiles.length) {
+    fileList.innerHTML = '<li>No images selected.</li>';
+    return;
+  }
+
+  const sorted = [...queuedFiles].sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
+  sorted.forEach((file, index) => {
+    const li = document.createElement('li');
+    li.textContent = `${index + 1}. ${file.name}`;
+    fileList.appendChild(li);
+  });
+};
+
+const handleFiles = files => {
+  queuedFiles = [...queuedFiles, ...files];
+  updateFileList();
+};
+
+const handleDrop = event => {
+  event.preventDefault();
+  dropZone.classList.remove('dragover');
+  if (event.dataTransfer?.files?.length) {
+    handleFiles([...event.dataTransfer.files]);
+  }
+};
+
+dropZone?.addEventListener('click', () => hiddenFileInput.click());
+dropZone?.addEventListener('keydown', event => {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    hiddenFileInput.click();
+  }
+});
+
+dropZone?.addEventListener('dragover', event => {
+  event.preventDefault();
+  dropZone.classList.add('dragover');
+});
+
+;['dragleave', 'dragend'].forEach(type => {
+  dropZone?.addEventListener(type, () => dropZone.classList.remove('dragover'));
+});
+
+hiddenFileInput?.addEventListener('change', event => {
+  if (event.target.files?.length) {
+    handleFiles([...event.target.files]);
+    hiddenFileInput.value = '';
+  }
+});
+
+form?.addEventListener('submit', async event => {
+  event.preventDefault();
+  if (!queuedFiles.length) {
+    alert('Please add at least one image.');
+    return;
+  }
+
+  const data = new FormData(form);
+  const seriesTitle = data.get('seriesTitle');
+  const seriesDescription = data.get('seriesDescription');
+  const chapterTitle = data.get('chapterTitle');
+  const coverFile = data.get('coverImage');
+
+  const coverImage = coverFile?.size ? await fileToDataUrl(coverFile) : null;
+  const series = await upsertSeries({ title: seriesTitle, description: seriesDescription, coverImage });
+
+  const pages = await Promise.all(
+    [...queuedFiles]
+      .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }))
+      .map(async (file, index) => ({
+        id: `${series.id}-page-${index}`,
+        index,
+        name: file.name,
+        src: await fileToDataUrl(file)
+      }))
+  );
+
+  await addChapter(series.id, { title: chapterTitle, pages });
+  form.reset();
+  queuedFiles = [];
+  updateFileList();
+  refreshLibrary();
+  alert('Chapter saved! You can now read it in the library.');
+});
+
+clearLibrary?.addEventListener('click', () => {
+  if (confirm('This will remove all series and chapters. Continue?')) {
+    libraryStore.reset();
+    queuedFiles = [];
+    updateFileList();
+    refreshLibrary();
+  }
+});
+
+refreshLibrary();
+updateFileList();

--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -1,0 +1,75 @@
+import { listSeries } from './storage.js';
+
+const grid = document.getElementById('seriesGrid');
+const emptyState = document.getElementById('emptyState');
+const searchInput = document.getElementById('seriesSearch');
+
+const renderSeries = seriesList => {
+  if (!grid) return;
+  grid.innerHTML = '';
+
+  if (!seriesList.length) {
+    emptyState?.classList.remove('hidden');
+    grid.classList.add('hidden');
+    return;
+  }
+
+  grid.classList.remove('hidden');
+  emptyState?.classList.add('hidden');
+
+  seriesList.forEach(series => {
+    const card = document.createElement('article');
+    card.className = 'series-card';
+
+    const cover = document.createElement('img');
+    cover.className = 'series-cover';
+    cover.alt = `${series.title} cover`;
+    cover.loading = 'lazy';
+    cover.src = series.coverImage || 'https://placehold.co/400x600/111827/94a3b8?text=Cover';
+
+    const meta = document.createElement('div');
+    meta.className = 'series-meta';
+    meta.innerHTML = `
+      <h3>${series.title}</h3>
+      <p>${series.description || 'No description yet.'}</p>
+      <p><strong>${series.chapters.length}</strong> chapter${series.chapters.length === 1 ? '' : 's'}</p>
+    `;
+
+    const actions = document.createElement('div');
+    actions.className = 'series-actions';
+
+    const viewButton = document.createElement('a');
+    viewButton.className = 'btn primary';
+    const firstChapter = series.chapters[0];
+    viewButton.href = firstChapter
+      ? `reader.html?series=${series.id}&chapter=${firstChapter.id}`
+      : 'admin.html';
+    viewButton.textContent = firstChapter ? 'Read' : 'Add Chapter';
+
+    const detailButton = document.createElement('a');
+    detailButton.className = 'btn secondary';
+    detailButton.href = `series.html#${series.id}`;
+    detailButton.textContent = 'Details';
+
+    actions.append(viewButton, detailButton);
+    card.append(cover, meta, actions);
+    grid.appendChild(card);
+  });
+};
+
+const filterSeries = term => {
+  const seriesList = listSeries();
+  const filtered = seriesList.filter(series =>
+    series.title.toLowerCase().includes(term.toLowerCase())
+  );
+  renderSeries(filtered);
+};
+
+if (grid) {
+  const seriesList = listSeries();
+  renderSeries(seriesList);
+
+  searchInput?.addEventListener('input', event => {
+    filterSeries(event.target.value);
+  });
+}

--- a/assets/js/reader.js
+++ b/assets/js/reader.js
@@ -1,0 +1,116 @@
+import { getSeries, getChapter, saveProgress, getProgress } from './storage.js';
+
+const params = new URLSearchParams(window.location.search);
+const seriesId = params.get('series');
+const chapterId = params.get('chapter');
+
+const seriesTitle = document.getElementById('seriesTitle');
+const chapterTitle = document.getElementById('chapterTitle');
+const pageContainer = document.getElementById('pageContainer');
+const chapterSelect = document.getElementById('chapterSelect');
+const backButton = document.getElementById('backButton');
+const prevChapterBtn = document.getElementById('prevChapter');
+const nextChapterBtn = document.getElementById('nextChapter');
+const readingProgress = document.getElementById('readingProgress');
+
+const init = () => {
+  if (!seriesId || !chapterId) {
+    window.location.href = 'index.html';
+    return;
+  }
+
+  const series = getSeries(seriesId);
+  if (!series) {
+    window.location.href = 'index.html';
+    return;
+  }
+
+  seriesTitle.textContent = series.title;
+
+  chapterSelect.innerHTML = '';
+  series.chapters.forEach(chapter => {
+    const option = document.createElement('option');
+    option.value = chapter.id;
+    option.textContent = chapter.title;
+    if (chapter.id === chapterId) option.selected = true;
+    chapterSelect.appendChild(option);
+  });
+
+  const currentChapter = getChapter(seriesId, chapterId);
+  if (!currentChapter) {
+    window.location.href = 'index.html';
+    return;
+  }
+
+  chapterTitle.textContent = currentChapter.title;
+  renderPages(currentChapter);
+  setupNavigation(series, currentChapter);
+  restoreProgress(seriesId, chapterId);
+};
+
+const renderPages = chapter => {
+  pageContainer.innerHTML = '';
+  chapter.pages
+    .sort((a, b) => a.index - b.index)
+    .forEach(page => {
+      const wrapper = document.createElement('figure');
+      wrapper.className = 'reader-page';
+      const img = document.createElement('img');
+      img.src = page.src;
+      img.alt = `${chapter.title} page ${page.index + 1}`;
+      img.loading = 'lazy';
+      wrapper.appendChild(img);
+      pageContainer.appendChild(wrapper);
+    });
+};
+
+const setupNavigation = (series, currentChapter) => {
+  const chapterIndex = series.chapters.findIndex(ch => ch.id === currentChapter.id);
+  const prevChapter = series.chapters[chapterIndex - 1];
+  const nextChapter = series.chapters[chapterIndex + 1];
+
+  const navigateTo = chapter => {
+    if (!chapter) return;
+    window.location.href = `reader.html?series=${series.id}&chapter=${chapter.id}`;
+  };
+
+  prevChapterBtn.disabled = !prevChapter;
+  nextChapterBtn.disabled = !nextChapter;
+
+  prevChapterBtn.onclick = () => navigateTo(prevChapter);
+  nextChapterBtn.onclick = () => navigateTo(nextChapter);
+
+  backButton.onclick = () => {
+    window.history.length > 1 ? window.history.back() : (window.location.href = 'series.html');
+  };
+
+  chapterSelect.onchange = event => {
+    const targetChapter = series.chapters.find(ch => ch.id === event.target.value);
+    navigateTo(targetChapter);
+  };
+};
+
+const restoreProgress = (seriesId, chapterId) => {
+  const saved = getProgress({ seriesId, chapterId });
+  if (saved) {
+    setTimeout(() => {
+      window.scrollTo({ top: saved.scrollOffset, behavior: 'auto' });
+    }, 50);
+  }
+};
+
+let saveTimer;
+window.addEventListener('scroll', () => {
+  clearTimeout(saveTimer);
+  saveTimer = setTimeout(() => {
+    if (!seriesId || !chapterId) return;
+    saveProgress({ seriesId, chapterId, scrollOffset: window.scrollY });
+    if (readingProgress) {
+      const totalHeight = document.documentElement.scrollHeight - window.innerHeight;
+      const percent = totalHeight > 0 ? Math.min(100, Math.round((window.scrollY / totalHeight) * 100)) : 0;
+      readingProgress.textContent = `Progress saved: ${percent}%`;
+    }
+  }, 300);
+});
+
+init();

--- a/assets/js/series.js
+++ b/assets/js/series.js
@@ -1,0 +1,67 @@
+import { listSeries } from './storage.js';
+
+const grid = document.getElementById('seriesGrid');
+const emptyState = document.getElementById('emptyState');
+const searchInput = document.getElementById('seriesSearch');
+
+const renderSeries = seriesList => {
+  if (!grid) return;
+  grid.innerHTML = '';
+
+  if (!seriesList.length) {
+    emptyState?.classList.remove('hidden');
+    grid.classList.add('hidden');
+    return;
+  }
+
+  emptyState?.classList.add('hidden');
+  grid.classList.remove('hidden');
+
+  seriesList.forEach(series => {
+    const card = document.createElement('article');
+    card.className = 'series-card';
+    card.id = series.id;
+
+    const cover = document.createElement('img');
+    cover.className = 'series-cover';
+    cover.loading = 'lazy';
+    cover.src = series.coverImage || 'https://placehold.co/400x600/111827/94a3b8?text=Cover';
+    cover.alt = `${series.title} cover`;
+
+    const meta = document.createElement('div');
+    meta.className = 'series-meta';
+    meta.innerHTML = `
+      <h3>${series.title}</h3>
+      <p>${series.description || 'No description yet.'}</p>
+    `;
+
+    const chapterList = document.createElement('ul');
+    chapterList.className = 'file-list';
+    series.chapters.forEach(chapter => {
+      const item = document.createElement('li');
+      const link = document.createElement('a');
+      link.href = `reader.html?series=${series.id}&chapter=${chapter.id}`;
+      link.textContent = chapter.title;
+      item.appendChild(link);
+      chapterList.appendChild(item);
+    });
+
+    card.append(cover, meta, chapterList);
+    grid.appendChild(card);
+  });
+};
+
+const filterSeries = term => {
+  const seriesList = listSeries();
+  const filtered = seriesList.filter(series =>
+    series.title.toLowerCase().includes(term.toLowerCase())
+  );
+  renderSeries(filtered);
+};
+
+const seriesList = listSeries();
+renderSeries(seriesList);
+
+searchInput?.addEventListener('input', event => {
+  filterSeries(event.target.value);
+});

--- a/assets/js/storage.js
+++ b/assets/js/storage.js
@@ -1,0 +1,132 @@
+const STORAGE_KEY = 'panelflow-library-v1';
+const PROGRESS_KEY = 'panelflow-progress-v1';
+
+const defaultLibrary = { series: {} };
+
+const readStorage = key => {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch (error) {
+    console.error('Storage read error', error);
+    return null;
+  }
+};
+
+const writeStorage = (key, value) => {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.error('Storage write error', error);
+  }
+};
+
+export const generateId = (prefix = 'id') => `${prefix}-${crypto.randomUUID()}`;
+
+export const libraryStore = {
+  load() {
+    return { ...defaultLibrary, ...readStorage(STORAGE_KEY) };
+  },
+  save(library) {
+    writeStorage(STORAGE_KEY, library);
+  },
+  reset() {
+    writeStorage(STORAGE_KEY, defaultLibrary);
+    writeStorage(PROGRESS_KEY, {});
+  }
+};
+
+export const progressStore = {
+  load() {
+    return readStorage(PROGRESS_KEY) || {};
+  },
+  save(progress) {
+    writeStorage(PROGRESS_KEY, progress);
+  }
+};
+
+export const upsertSeries = async ({ title, description, coverImage }) => {
+  const library = libraryStore.load();
+  const existing = Object.values(library.series).find(
+    series => series.title.toLowerCase() === title.trim().toLowerCase()
+  );
+
+  const seriesId = existing?.id || generateId('series');
+
+  const series = {
+    id: seriesId,
+    title: title.trim(),
+    description: description?.trim() || '',
+    coverImage: coverImage || existing?.coverImage || '',
+    chapters: existing?.chapters || {}
+  };
+
+  library.series[seriesId] = series;
+  libraryStore.save(library);
+  return series;
+};
+
+export const addChapter = async (seriesId, { title, pages }) => {
+  const library = libraryStore.load();
+  const series = library.series[seriesId];
+  if (!series) throw new Error('Series not found');
+
+  const chapterId = generateId('chapter');
+  series.chapters[chapterId] = {
+    id: chapterId,
+    title: title.trim(),
+    createdAt: new Date().toISOString(),
+    pages
+  };
+
+  library.series[seriesId] = series;
+  libraryStore.save(library);
+  return series.chapters[chapterId];
+};
+
+export const listSeries = () => {
+  const library = libraryStore.load();
+  return Object.values(library.series).map(series => ({
+    ...series,
+    chapters: Object.values(series.chapters).sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))
+  }));
+};
+
+export const getSeries = seriesId => {
+  const library = libraryStore.load();
+  const series = library.series[seriesId];
+  if (!series) return null;
+  return {
+    ...series,
+    chapters: Object.values(series.chapters).sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))
+  };
+};
+
+export const getChapter = (seriesId, chapterId) => {
+  const series = getSeries(seriesId);
+  if (!series) return null;
+  return series.chapters.find(chapter => chapter.id === chapterId) || null;
+};
+
+export const saveProgress = ({ seriesId, chapterId, scrollOffset }) => {
+  const progress = progressStore.load();
+  progress[`${seriesId}:${chapterId}`] = {
+    scrollOffset,
+    updatedAt: Date.now()
+  };
+  progressStore.save(progress);
+};
+
+export const getProgress = ({ seriesId, chapterId }) => {
+  const progress = progressStore.load();
+  return progress[`${seriesId}:${chapterId}`] || null;
+};
+
+export const fileToDataUrl = file =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,0 +1,39 @@
+const THEME_KEY = 'panelflow-theme';
+
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+const root = document.documentElement;
+const toggle = document.getElementById('themeToggle');
+
+const applyTheme = theme => {
+  root.setAttribute('data-theme', theme);
+  if (toggle) {
+    toggle.setAttribute('aria-pressed', theme === 'dark' ? 'false' : 'true');
+  }
+  localStorage.setItem(THEME_KEY, theme);
+};
+
+const initTheme = () => {
+  const saved = localStorage.getItem(THEME_KEY);
+  const theme = saved || (prefersDark.matches ? 'dark' : 'light');
+  applyTheme(theme);
+};
+
+if (toggle) {
+  toggle.addEventListener('click', () => {
+    const next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    applyTheme(next);
+  });
+}
+
+prefersDark.addEventListener('change', event => {
+  if (!localStorage.getItem(THEME_KEY)) {
+    applyTheme(event.matches ? 'dark' : 'light');
+  }
+});
+
+initTheme();
+
+const year = document.getElementById('year');
+if (year) {
+  year.textContent = new Date().getFullYear();
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Manhwa Reader</title>
+  <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body class="page-home">
+  <header class="site-header">
+    <div class="logo">PanelFlow</div>
+    <nav class="main-nav">
+      <a href="index.html" class="active">Home</a>
+      <a href="series.html">Series</a>
+      <a href="admin.html">Upload</a>
+    </nav>
+    <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme"></button>
+  </header>
+
+  <main class="home-content">
+    <section class="hero">
+      <div class="hero-copy">
+        <h1>Discover Fresh Manhwa Adventures</h1>
+        <p>Browse, read, and manage chapters with a smooth vertical experience designed for both desktop and mobile readers.</p>
+        <div class="cta-group">
+          <a class="btn primary" href="series.html">Browse Series</a>
+          <a class="btn secondary" href="admin.html">Upload Chapters</a>
+        </div>
+      </div>
+      <div class="hero-visual" aria-hidden="true"></div>
+    </section>
+
+    <section class="library">
+      <header class="section-header">
+        <h2>Continue Reading</h2>
+        <div class="filter-group">
+          <input type="search" id="seriesSearch" placeholder="Search series..." />
+        </div>
+      </header>
+      <div id="seriesGrid" class="series-grid hidden"></div>
+      <p id="emptyState" class="empty-state hidden">Upload your first series to get started.</p>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>&copy; <span id="year"></span> PanelFlow. Crafted for immersive reading.</p>
+  </footer>
+
+  <script type="module" src="assets/js/theme.js"></script>
+  <script type="module" src="assets/js/storage.js"></script>
+  <script type="module" src="assets/js/home.js"></script>
+</body>
+</html>

--- a/reader.html
+++ b/reader.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Reader - PanelFlow</title>
+  <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body class="page-reader">
+  <header class="reader-header">
+    <a class="logo" href="index.html">PanelFlow</a>
+    <div class="reader-controls">
+      <button id="backButton" class="btn secondary">&larr; Library</button>
+      <select id="chapterSelect" aria-label="Select chapter"></select>
+      <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme"></button>
+    </div>
+  </header>
+
+  <main class="reader-main">
+    <article class="reader-meta">
+      <h1 id="seriesTitle"></h1>
+      <h2 id="chapterTitle"></h2>
+    </article>
+    <section id="pageContainer" class="page-container" aria-live="polite"></section>
+    <nav class="reader-pagination">
+      <button id="prevChapter" class="btn secondary">Previous Chapter</button>
+      <button id="nextChapter" class="btn primary">Next Chapter</button>
+    </nav>
+  </main>
+
+  <footer class="reader-footer">
+    <p id="readingProgress">Scroll to read. Progress saves automatically.</p>
+  </footer>
+
+  <script type="module" src="assets/js/theme.js"></script>
+  <script type="module" src="assets/js/storage.js"></script>
+  <script type="module" src="assets/js/reader.js"></script>
+</body>
+</html>

--- a/series.html
+++ b/series.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Series Library - PanelFlow</title>
+  <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body class="page-series">
+  <header class="site-header">
+    <div class="logo">PanelFlow</div>
+    <nav class="main-nav">
+      <a href="index.html">Home</a>
+      <a href="series.html" class="active">Series</a>
+      <a href="admin.html">Upload</a>
+    </nav>
+    <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme"></button>
+  </header>
+
+  <main class="page-content">
+    <header class="section-header">
+      <h1>All Series</h1>
+      <div class="filter-group">
+        <input type="search" id="seriesSearch" placeholder="Search series..." />
+      </div>
+    </header>
+    <div id="seriesGrid" class="series-grid hidden"></div>
+    <p id="emptyState" class="empty-state hidden">No series yet. Upload via the admin panel.</p>
+  </main>
+
+  <footer class="site-footer">
+    <p>&copy; <span id="year"></span> PanelFlow.</p>
+  </footer>
+
+  <script type="module" src="assets/js/theme.js"></script>
+  <script type="module" src="assets/js/storage.js"></script>
+  <script type="module" src="assets/js/series.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add landing, series library, reader, and admin upload pages with responsive dark-first UI
- implement localStorage-backed library, chapter management, and reading progress helpers
- build drag-and-drop uploader for chapter images with lazy-loaded reader rendering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e07f4a414c8330a723db873b4a2158